### PR TITLE
Remove unnecessary shebang from non-script file

### DIFF
--- a/repo2module/cli.py
+++ b/repo2module/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import click


### PR DESCRIPTION
The `cli.py` file doesn't have executable bits anyway, so there
is no reason for it to have shebang. Moreover rpmlint rambles about
it for an RPM package that I created for this tool.